### PR TITLE
🚀 feat: add Docker Hub login and push step to GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,18 +38,26 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-  docker_build:
+  docker_build_push:
     needs:
       - validate_schema
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
-          push: false
-          tags: image:latest
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:latest


### PR DESCRIPTION
The changes in this commit add a new step to the GitHub Actions workflow. This step is responsible for logging in to Docker Hub and pushing the Docker image to the Docker Hub repository. The step is conditional and will only run if the event name is not a pull request. The step uses the `docker/login-action@v3` action and provides the Docker Hub username and token from the secrets. After logging in, the `docker/build-push-action@v5` action is used to build and push the Docker image to the repository. The context is set to the current directory and the push is conditional based on the event name. The image is tagged with the latest tag using the Docker Hub username and the repository name from the GitHub event.