### PR TITLE
🔨 chore: add additionalProperties: false to request schemas in messageRoutes and authenticationRoutes

### DIFF
--- a/src/modules/authentication/routes.ts
+++ b/src/modules/authentication/routes.ts
@@ -32,6 +32,7 @@ const authenticationRoutes: FastifyPluginAsync = async (fastify) => {
             lastName: { type: "string", minLength: 2 },
           },
           required: ["email", "password", "confirmPassword"],
+          additionalProperties: false,
         },
         response: {
           204: {},
@@ -69,6 +70,7 @@ const authenticationRoutes: FastifyPluginAsync = async (fastify) => {
             password: { type: "string", pattern: PASSWORD_REGEX },
           },
           required: ["email", "password"],
+          additionalProperties: false,
         },
         response: {
           200: {
@@ -112,6 +114,7 @@ const authenticationRoutes: FastifyPluginAsync = async (fastify) => {
             email: { type: "string", format: "email" },
           },
           required: ["email"],
+          additionalProperties: false,
         },
         response: {
           200: {
@@ -165,6 +168,7 @@ const authenticationRoutes: FastifyPluginAsync = async (fastify) => {
             confirmPassword: { type: "string", pattern: PASSWORD_REGEX },
           },
           required: ["token", "newPassword", "confirmPassword"],
+          additionalProperties: false,
         },
         response: {
           202: {

--- a/src/modules/message/route.ts
+++ b/src/modules/message/route.ts
@@ -23,6 +23,7 @@ const messageRoutes: FastifyPluginAsync = async (fastify): Promise<void> => {
             receiverId: { type: "number" },
           },
           required: ["content", "receiverId"],
+          additionalProperties: false,
         },
         response: {
           200: {
@@ -70,6 +71,7 @@ const messageRoutes: FastifyPluginAsync = async (fastify): Promise<void> => {
           properties: {
             ...cursorPaginationDefs,
           },
+          additionalProperties: false,
         },
         response: {
           200: {
@@ -167,6 +169,7 @@ const messageRoutes: FastifyPluginAsync = async (fastify): Promise<void> => {
             before: { type: "number", minimum: 0 },
           },
           required: ["receiverId"],
+          additionalProperties: false,
         },
         response: {
           200: {


### PR DESCRIPTION
The additionalProperties: false option ensures that only the specified properties are allowed in the request bodies of the corresponding routes. This improves security and prevents unexpected or unauthorized data from being included in the requests.