### PR TITLE
✨ Add mail templates to dist folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,6 @@ COPY --from=builder /app/prisma ./prisma
 RUN ./node_modules/.bin/prisma generate
 
 COPY --from=builder /app/dist ./dist
-COPY --from=builder /app/src/mail/templates ./dist/modules/mail/templates
+COPY --from=builder /app/src/modules/mail/templates ./dist/modules/mail/templates
 
 CMD sh -c "npm run prisma:deploy && npm run start"

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,6 @@ COPY --from=builder /app/prisma ./prisma
 RUN ./node_modules/.bin/prisma generate
 
 COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/src/mail/templates ./dist/modules/mail/templates
 
 CMD sh -c "npm run prisma:deploy && npm run start"


### PR DESCRIPTION
Added a copy command to include mail templates from the source folder into the
dist folder. This change is necessary for the application to properly access
and utilize the mail templates during runtime.