### PR TITLE
✨ Refactor: Update reset password link in authenticationRoutes

### DIFF
--- a/src/modules/authentication/routes.ts
+++ b/src/modules/authentication/routes.ts
@@ -159,7 +159,7 @@ const authenticationRoutes: FastifyPluginAsync = async (fastify) => {
       }
 
       const token = jwt.createForgotPasswordToken(user);
-      const resetLink = createServerURL(`/auth/reset-password?token=${token}`);
+      const resetLink = createServerURL(`/reset-password?token=${token}`);
       await mail.send<"ForgotPassword">({
         to: request.body.email,
         template: "ForgotPassword",


### PR DESCRIPTION
Shortened the reset password link generated in authenticationRoutes to remove redundant '/auth/' path for better readability and simplicity.

- Changed reset password link generation to use createServerURL(`/reset-password?token=${token}`)
- Updated the mail.send<"ForgotPassword"> parameters accordingly