### PR TITLE
✨ Refactor userRoutes to use "/users/me" endpoint

### DIFF
--- a/src/modules/user/route.ts
+++ b/src/modules/user/route.ts
@@ -9,7 +9,7 @@ const userRoutes: FastifyPluginAsync = async (fastify) => {
   const server = fastify.withTypeProvider<JsonSchemaToTsProvider>();
 
   server.get(
-    "/me",
+    "/users/me",
     {
       schema: {
         tags: ["User"],

--- a/test/modules/user/route.test.ts
+++ b/test/modules/user/route.test.ts
@@ -11,11 +11,11 @@ test("User routes", async (t) => {
 
   const userQueriesStub = Sinon.stub(userQueries);
 
-  await t.test("GET /me", async (t) => {
+  await t.test("GET /users/me", async (t) => {
     await t.test("Should throw unauthorized if request is not authenticated", async (t) => {
       const response = await app.inject({
         method: "GET",
-        url: "/me",
+        url: "/users/me",
       });
 
       assert.equal(response.statusCode, StatusCodes.UNAUTHORIZED);
@@ -31,7 +31,7 @@ test("User routes", async (t) => {
 
       const response = await app.inject({
         method: "GET",
-        url: "/me",
+        url: "/users/me",
         headers: {
           authorization: `Bearer ${loginToken}`,
         },


### PR DESCRIPTION
Refactor the userRoutes Fastify plugin to use the "/users/me" endpoint instead of "/me". This change helps to improve consistency and clarity in the API routes. Update related tests accordingly.